### PR TITLE
Add ZServer with WebSockets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,3 @@
 FROM plone:5.2.0
+COPY buildout.cfg /plone/instance/site.cfg
+RUN gosu plone buildout -c site.cfg

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,6 +2,10 @@
 extends =
   buildout-base.cfg
 
+# precompiler fails for various packages due to py2 code
+parts -=
+  precompiler
+
 extensions =
 effective-user = plone
 buildout-user = plone
@@ -11,6 +15,11 @@ parts +=
   zeo
   mrbob
   plonesite
+
+find-links +=
+  https://github.com/datakurre/ZServer/archive/datakurre/master.tar.gz#egg=ZServer-4.1.dev0
+  https://github.com/plone/plone.recipe.zope2instance/archive/datakurre/zserver.tar.gz#egg=plone.recipe.zope2instance-6.2.1.dev0
+  https://github.com/datakurre/collective.wsevents/archive/master.tar.gz#egg=collective.wsevents-1.0a1
 
 [client1]
 recipe =
@@ -24,6 +33,9 @@ recipe = plone.recipe.zeoserver
 zeo-address = 8080
 
 [instance]
+eggs +=
+  ZServer[http2]
+  collective.wsevents
 zcml-additional =
   <configure xmlns="http://namespaces.zope.org/zope" xmlns:plone="http://namespaces.plone.org/plone">
   <plone:CORSPolicy
@@ -35,6 +47,7 @@ zcml-additional =
     max_age="3600"
     />
   </configure>
+wsgi = off
 
 # Requires gcc, thus install it on image build
 [mrbob]
@@ -86,3 +99,8 @@ PyJWT = 1.7.1
 # develop.cfg
 collective.checkdocs = 0.2
 zest.pocompile = 1.4
+
+# websockets
+ZServer = 4.1.dev0
+plone.recipe.zope2instance = 6.2.1.dev0
+collective.wsevents = 1.0a1


### PR DESCRIPTION
@davilima6 Thanks. This was easier than I expected.

Installing collective.wsevents from add-ons control panels gives the full websocket support for GatsbyJS and content rule for displaying websocket based notifications.